### PR TITLE
Loads data in separate thread to avoid blocking the UI

### DIFF
--- a/foojaysupport/src/main/java/io/foojay/support/BundleTableModel.java
+++ b/foojaysupport/src/main/java/io/foojay/support/BundleTableModel.java
@@ -40,6 +40,7 @@ public class BundleTableModel extends AbstractTableModel {
     public List<Pkg> getBundles() { return bundles; }
     public void setBundles(final List<Pkg> bundles) {
         this.bundles = bundles;
+        this.fireTableDataChanged();
     }
 
     public String getColumnName(final int col) {


### PR DESCRIPTION
Closes issue #10 but there's more multithreading issues to be fixed. In particular I think all discoclient access needs a lock, I've seen `ConcurentModificationException`s for multiple things...